### PR TITLE
time successfully wasted, but ids are unique.

### DIFF
--- a/packages/core/src/util/id.ts
+++ b/packages/core/src/util/id.ts
@@ -16,3 +16,19 @@ const prefixes = {
 export function createID(prefix: keyof typeof prefixes): string {
   return [prefixes[prefix], ulid()].join("_");
 }
+
+const _typeCheckUniquePrefixes: ErrorIfDuplicates<typeof prefixes> = prefixes;
+
+type Duplicate<T extends Record<string, string>> = {
+  [K in keyof T]: {
+    [L in keyof T]: T[K] extends T[L] ? (K extends L ? never : K) : never;
+  }[keyof T];
+}[keyof T];
+
+type HasDuplicates<T extends Record<string, string>> =
+  Duplicate<T> extends never ? false : true;
+
+type ErrorIfDuplicates<T extends Record<string, string>> =
+  HasDuplicates<T> extends true
+    ? { error: `Duplicate values found: ${Duplicate<T> & string}` }
+    : T;


### PR DESCRIPTION
```ts
const prefixes = {
  user: "usr",
  cartItem: "itm",
  shelfItem: "itm",
} as const;

...
// errors due to duplicate prefix: "itm"
const _typeCheckUniquePrefixes: ErrorIfDuplicates<typeof prefixes> = prefixes;
```