### PR TITLE
how to use arguments with wish x bubble tea

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,14 @@
+### Usage
+
+#### Applying promotional codes to a session
+
+```sh
+ssh -t terminal.shop -- "archbtw"
+```
+
+`-t` forces pty allocation, `--` tells ssh to forward the following commands to
+the application.
+
 ### Setup
 
 - install bun https://bun.sh/

--- a/packages/go/cmd/cli/main.go
+++ b/packages/go/cmd/cli/main.go
@@ -21,6 +21,7 @@ func main() {
 	model, err := tui.NewModel(
 		lipgloss.DefaultRenderer(),
 		"fingerprint",
+		"",
 	)
 	if err != nil {
 		panic(err)

--- a/packages/go/pkg/tui/root.go
+++ b/packages/go/pkg/tui/root.go
@@ -13,8 +13,10 @@ import (
 	"github.com/terminaldotshop/terminal/go/pkg/tui/theme"
 )
 
-type page = int
-type size = int
+type (
+	page = int
+	size = int
+)
 
 const (
 	menuPage page = iota
@@ -61,6 +63,7 @@ type model struct {
 	renderer        *lipgloss.Renderer
 	theme           theme.Theme
 	fingerprint     string
+	promotion       string
 	viewportWidth   int
 	viewportHeight  int
 	widthContainer  int
@@ -92,12 +95,12 @@ type state struct {
 	menu          menuState
 }
 
-type children struct {
-}
+type children struct{}
 
 func NewModel(
 	renderer *lipgloss.Renderer,
 	fingerprint string,
+	promotion string,
 ) (tea.Model, error) {
 	api.Init()
 
@@ -108,6 +111,7 @@ func NewModel(
 		page:        splashPage,
 		renderer:    renderer,
 		fingerprint: fingerprint,
+		promotion:   promotion,
 		theme:       theme.BasicTheme(renderer, nil),
 		faqs:        LoadFaqs(),
 		accountPages: []page{
@@ -360,7 +364,6 @@ func (m model) View() string {
 				Render(child),
 		)
 	}
-
 }
 
 func (m model) getContent() string {


### PR DESCRIPTION
incomplete feature given it just saves the arg value to the model without doing anything to it. We do something similar in Soft Serve to open a given repo in the TUI on startup https://github.com/charmbracelet/soft-serve/blob/main/pkg/ssh/session.go#L49

https://github.com/charmbracelet/soft-serve?tab=readme-ov-file#where-can-i-see-it

If you don't pass `-t` in the ssh connection and try to use args, ssh won't request a pty which will block bubble tea from working as far as I know.