### PR TITLE
Check the flag actually exists

### DIFF
--- a/packages/core/src/actor.ts
+++ b/packages/core/src/actor.ts
@@ -56,7 +56,7 @@ export namespace Actor {
         .where(eq(userTable.id, userID()))
         .then((rows) => {
           const flags = rows[0]?.flags;
-          if (!flags)
+          if (!flags || !flags[flag])
             throw new VisibleError(
               "forbidden",
               ErrorCodes.Permission.INSUFFICIENT_PERMISSIONS,


### PR DESCRIPTION
I assume this is a small bug, since the function only check if flags exists in database and not the specific flag.

